### PR TITLE
解决生成sourcemap 错误的bug

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -15,6 +15,7 @@ export function imageRequirePlugin(){
             })
             return {
                 code,
+                map: null
             }
         }
     }


### PR DESCRIPTION
解决vite build时，报Sourcemap is likely to be incorrect: a plugin (vite-plugin-image-require) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help的错误，参考：https://rollupjs.org/guide/en/#transform